### PR TITLE
Decreased result summary length

### DIFF
--- a/cogs/arxiv.py
+++ b/cogs/arxiv.py
@@ -50,7 +50,7 @@ class Arxiv(commands.Cog):
             embed = Embed(color=0xFF5733)
             embed.set_author(name="ArXiV", url="https://arxiv.org", icon_url=self.bot.user.avatar.url)
             for result in search.results():
-                embed_resume = self._format_message(result.summary, n=750)
+                embed_resume = self._format_message(result.summary, n=350)
                 if len(embed) + len(embed_resume) + len(result.title) > 6000: continue
                 embed.add_field(
                     name=f"{result.title}",


### PR DESCRIPTION
The maximum length of the result summary was set to 750 earlier. Since, max allowed size of embed is 6000, all the 10 results were not able to fit in a single embed. Setting maximum result summary to 350 allows all the results to fit in the embed.

This resolves the issue #3 